### PR TITLE
Atomic migrations

### DIFF
--- a/.changeset/fifty-poems-joke.md
+++ b/.changeset/fifty-poems-joke.md
@@ -1,0 +1,5 @@
+---
+"@zemble/migrations": patch
+---
+
+Add lock handling

--- a/.changeset/thin-coins-wink.md
+++ b/.changeset/thin-coins-wink.md
@@ -1,0 +1,5 @@
+---
+"@zemble/mongodb": patch
+---
+
+Make migrations atomic

--- a/packages/migrations/MigrationLockError.ts
+++ b/packages/migrations/MigrationLockError.ts
@@ -1,0 +1,6 @@
+export class MigrationLockError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'MigrationLockError'
+  }
+}

--- a/packages/migrations/plugin.test.ts
+++ b/packages/migrations/plugin.test.ts
@@ -1,5 +1,6 @@
+import { runBeforeServe } from '@zemble/core'
 import { createTestApp } from '@zemble/core/test-utils'
-import { test, expect } from 'bun:test'
+import { mock, test, expect } from 'bun:test'
 
 import plugin, { migrateUp } from './plugin'
 
@@ -11,9 +12,17 @@ test('Should return world!', async () => {
 })
 
 test('migrateUp', async () => {
-  const app = await createTestApp(plugin)
-  const count = await migrateUp({
+  await createTestApp(plugin)
+  const { count } = await migrateUp({
 
   })
   expect(count).toBe(0)
+})
+
+test('beforeStart', async () => {
+  const migrateUpMock = mock(migrateUp)
+  const app = await createTestApp(plugin)
+
+  await runBeforeServe(app)
+  expect(migrateUpMock).toHaveBeenCalledTimes(0)
 })

--- a/packages/migrations/plugin.test.ts
+++ b/packages/migrations/plugin.test.ts
@@ -1,11 +1,19 @@
 import { createTestApp } from '@zemble/core/test-utils'
 import { test, expect } from 'bun:test'
 
-import plugin from './plugin'
+import plugin, { migrateUp } from './plugin'
 
 test('Should return world!', async () => {
   const app = await createTestApp(plugin)
   const res = await app.hono.request('/')
 
   expect(await res.text()).toContain('Hello Zemble! Serving ')
+})
+
+test('migrateUp', async () => {
+  const app = await createTestApp(plugin)
+  const count = await migrateUp({
+
+  })
+  expect(count).toBe(0)
 })

--- a/packages/mongodb/migration-adapter-with-transactions.ts
+++ b/packages/mongodb/migration-adapter-with-transactions.ts
@@ -48,10 +48,11 @@ function MongoMigrationAdapterWithTransaction<TProgress extends JsonValue = Json
         }, {
           $set: {
             name,
-            error: JSON.stringify(e),
+            error: e instanceof Error ? e.message : JSON.stringify(e),
             erroredAt: new Date(),
           },
         }, { upsert: true, session })
+        throw e
       } finally {
         await session.endSession()
       }
@@ -73,10 +74,11 @@ function MongoMigrationAdapterWithTransaction<TProgress extends JsonValue = Json
         }, {
           $set: {
             name,
-            error: JSON.stringify(e),
+            error: e instanceof Error ? e.message : JSON.stringify(e),
             erroredAt: new Date(),
           },
         }, { upsert: true })
+        throw e
       } finally {
         await session.endSession()
       }

--- a/packages/mongodb/migration-adapter.ts
+++ b/packages/mongodb/migration-adapter.ts
@@ -1,4 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
+import { MigrationLockError } from '@zemble/migrations/MigrationLockError'
+
 import type { MigrationAdapter, MigrationStatus } from '@zemble/migrations'
 import type { Collection } from 'mongodb'
 import type { JsonValue } from 'type-fest'
@@ -25,7 +27,7 @@ export async function acquireUpLock<TProgress extends JsonValue = JsonValue>(nam
     })
   } catch (e) {
     const error = e instanceof Error && e.message.includes('duplicate key error')
-      ? new Error(`Migration "${name}" (up) is already running`)
+      ? new MigrationLockError(`Migration "${name}" (up) is already running`)
       : e
 
     throw error

--- a/packages/mongodb/migration-adapter.ts
+++ b/packages/mongodb/migration-adapter.ts
@@ -1,34 +1,71 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import type { MigrationAdapter, MigrationStatus } from '@zemble/migrations'
+import type { Collection } from 'mongodb'
 import type { JsonValue } from 'type-fest'
 
 type Config = { readonly providers: Zemble.Providers, readonly collectionName?: string }
 
-function getCollection<TProgress extends JsonValue = JsonValue>(config: Config) {
+export async function getCollection<TProgress extends JsonValue = JsonValue>(config: Config) {
   const db = config.providers.mongodb?.db
   if (!db) throw new Error('MongoDB client not provided or initialized')
 
   const collectionName = config.collectionName ?? 'migrations'
 
+  await db.createIndex(collectionName, { name: 1 }, { unique: true })
+
   const collection = db.collection<MigrationStatus<TProgress>>(collectionName)
   return collection
+}
+
+export async function acquireUpLock<TProgress extends JsonValue = JsonValue>(name: string, collection: Collection<MigrationStatus<TProgress>>) {
+  try {
+    await collection.findOneAndUpdate({
+      name,
+      completedAt: { $exists: false },
+    }, {
+      $set: {
+        name,
+        startedAt: new Date(),
+      },
+    }, { upsert: true })
+  } catch (e) {
+    const error = e instanceof Error && e.message.includes('duplicate key error')
+      ? new Error(`Migration "${name}" (up) is already running`)
+      : e
+
+    throw error
+  }
+}
+
+export const acquireDownLock = async <TProgress extends JsonValue = JsonValue>(name: string, collection: Collection<MigrationStatus<TProgress>>) => {
+  try {
+    await collection.findOneAndUpdate({
+      name,
+      startedDownAt: { $exists: false },
+    }, {
+      $set: {
+        name,
+        startedDownAt: new Date(),
+      },
+    }, { upsert: true })
+  } catch (e) {
+    const error = e instanceof Error && e.message.includes('duplicate key error')
+      ? new Error(`Migration "${name}" (down) is already running`)
+      : e
+
+    throw error
+  }
 }
 
 function MongoMigrationAdapter<TProgress extends JsonValue = JsonValue>(config: Config): MigrationAdapter<TProgress> {
   return {
     up: async (name, runMigration) => {
-      try {
-        await getCollection(config).findOneAndUpdate({
-          name,
-        }, {
-          $set: {
-            name,
-            startedAt: new Date(),
-          },
-        }, { upsert: true })
+      const collection = await getCollection(config)
+      await acquireUpLock(name, collection)
 
+      try {
         await runMigration()
-        await getCollection(config).findOneAndUpdate({
+        await collection.findOneAndUpdate({
           name,
         }, {
           $set: {
@@ -38,7 +75,7 @@ function MongoMigrationAdapter<TProgress extends JsonValue = JsonValue>(config: 
           },
         }, { upsert: true })
       } catch (e) {
-        await getCollection(config).findOneAndUpdate({
+        await collection.findOneAndUpdate({
           name,
         }, {
           $set: {
@@ -50,20 +87,15 @@ function MongoMigrationAdapter<TProgress extends JsonValue = JsonValue>(config: 
       }
     },
     down: async (name, runMigration) => {
-      await getCollection(config).findOneAndUpdate({
-        name,
-      }, {
-        $set: {
-          name,
-          startedDownAt: new Date(),
-        },
-      }, { upsert: true })
+      const collection = await getCollection(config)
+
+      await acquireDownLock(name, collection)
 
       try {
         await runMigration()
-        await getCollection(config).deleteOne({ name })
+        await collection.deleteOne({ name })
       } catch (e) {
-        await getCollection(config).findOneAndUpdate({
+        await collection.findOneAndUpdate({
           name,
         }, {
           $set: {
@@ -75,12 +107,14 @@ function MongoMigrationAdapter<TProgress extends JsonValue = JsonValue>(config: 
       }
     },
     status: async () => {
-      const res = getCollection<TProgress>(config).find().toArray()
+      const collection = await getCollection<TProgress>(config)
+      const res = await collection.find().toArray()
 
       return res
     },
     progress: async (migrationStatus) => {
-      await getCollection(config).findOneAndUpdate({
+      const collection = await getCollection(config)
+      await collection.findOneAndUpdate({
         name: migrationStatus.name,
       }, {
         $set: {

--- a/packages/mongodb/migration.test.ts
+++ b/packages/mongodb/migration.test.ts
@@ -1,0 +1,95 @@
+import {
+  afterAll, afterEach, beforeAll, expect, mock, test,
+} from 'bun:test'
+import { ObjectId } from 'mongodb'
+
+import MongoMigrationAdapterWithTransaction from './migration-adapter-with-transactions'
+import plugin from './plugin'
+import { setupBeforeAll, teardownAfterAll, tearDownAfterEach } from './test-setup'
+
+beforeAll(setupBeforeAll)
+
+afterAll(teardownAfterAll)
+
+afterEach(tearDownAfterEach)
+
+/* test('test', async () => {
+  expect(1).toBe(1)
+})
+
+test('run migration', async () => {
+  const mongodbPlugin = plugin
+  const adapter = MongoMigrationAdapterWithTransaction({
+    providers: mongodbPlugin.providers,
+    collectionName: 'migrations',
+  })
+  await adapter.up('testing', async () => {
+    // empty migration
+  })
+
+  const migrations = await mongodbPlugin.providers.mongodb?.db.collection('migrations').find().toArray()
+  expect(migrations).toHaveLength(1)
+  expect(migrations?.[0]).toStrictEqual(
+    {
+      name: 'testing',
+      startedAt: expect.any(Date),
+      _id: expect.any(ObjectId),
+      completedAt: expect.any(Date),
+      error: null,
+    },
+  )
+})
+
+test('run migration again', async () => {
+  const mongodbPlugin = plugin
+  const adapter = MongoMigrationAdapterWithTransaction({
+    providers: mongodbPlugin.providers,
+    collectionName: 'migrations',
+  })
+  await adapter.up('testing', async () => {
+    // empty migration
+  })
+
+  const migrations = await mongodbPlugin.providers.mongodb?.db.collection('migrations').find().toArray()
+  expect(migrations).toHaveLength(1)
+  expect(migrations?.[0]).toStrictEqual(
+    {
+      name: 'testing',
+      startedAt: expect.any(Date),
+      _id: expect.any(ObjectId),
+      completedAt: expect.any(Date),
+      error: null,
+    },
+  )
+}) */
+
+test('run concurrent migrations', async () => {
+  const mongodbPlugin = plugin
+  const adapter = MongoMigrationAdapterWithTransaction({
+    providers: mongodbPlugin.providers,
+    collectionName: 'migrations',
+  })
+  const migrationRunner = mock(async () => {
+    await new Promise((resolve) => { setTimeout(resolve, 100) })
+  })
+
+  const migration1 = adapter.up('testing', migrationRunner)
+
+  const migration2 = adapter.up('testing', migrationRunner)
+
+  await Promise.allSettled([migration1, migration2])
+
+  const migrations = await mongodbPlugin.providers.mongodb?.db.collection('migrations').find().toArray()
+
+  expect(migrations).toHaveLength(1)
+  expect(migrationRunner).toHaveBeenCalledTimes(1)
+  expect(migrations?.[0]).toStrictEqual(
+    {
+      name: 'testing',
+      startedAt: expect.any(Date),
+      _id: expect.any(ObjectId),
+      completedAt: expect.any(Date),
+      error: null,
+    },
+  )
+})

--- a/packages/mongodb/migration.test.ts
+++ b/packages/mongodb/migration.test.ts
@@ -13,10 +13,6 @@ afterAll(teardownAfterAll)
 
 afterEach(tearDownAfterEach)
 
-/* test('test', async () => {
-  expect(1).toBe(1)
-})
-
 test('run migration', async () => {
   const mongodbPlugin = plugin
   const adapter = MongoMigrationAdapterWithTransaction({
@@ -40,29 +36,6 @@ test('run migration', async () => {
   )
 })
 
-test('run migration again', async () => {
-  const mongodbPlugin = plugin
-  const adapter = MongoMigrationAdapterWithTransaction({
-    providers: mongodbPlugin.providers,
-    collectionName: 'migrations',
-  })
-  await adapter.up('testing', async () => {
-    // empty migration
-  })
-
-  const migrations = await mongodbPlugin.providers.mongodb?.db.collection('migrations').find().toArray()
-  expect(migrations).toHaveLength(1)
-  expect(migrations?.[0]).toStrictEqual(
-    {
-      name: 'testing',
-      startedAt: expect.any(Date),
-      _id: expect.any(ObjectId),
-      completedAt: expect.any(Date),
-      error: null,
-    },
-  )
-}) */
-
 test('run concurrent migrations', async () => {
   const mongodbPlugin = plugin
   const adapter = MongoMigrationAdapterWithTransaction({
@@ -77,7 +50,9 @@ test('run concurrent migrations', async () => {
 
   const migration2 = adapter.up('testing', migrationRunner)
 
-  await Promise.allSettled([migration1, migration2])
+  const migration3 = adapter.up('testing', migrationRunner)
+
+  await Promise.allSettled([migration1, migration2, migration3])
 
   const migrations = await mongodbPlugin.providers.mongodb?.db.collection('migrations').find().toArray()
 

--- a/packages/mongodb/test-setup.ts
+++ b/packages/mongodb/test-setup.ts
@@ -1,0 +1,28 @@
+/* eslint-disable functional/immutable-data, import/no-extraneous-dependencies */
+
+import generateKeys from '@zemble/auth/generate-keys'
+import { setupEnvOverride, resetEnv, createTestApp } from '@zemble/core/test-utils'
+import plugin from '@zemble/migrations/plugin'
+import { startInMemoryInstanceAndConfigurePlugin, closeAndStopInMemoryInstance, emptyAllCollections } from '@zemble/mongodb/test-utils'
+
+export const setupBeforeAll = async () => {
+  const { privateKey, publicKey } = await generateKeys()
+
+  setupEnvOverride({ PUBLIC_KEY: publicKey, PRIVATE_KEY: privateKey })
+
+  await startInMemoryInstanceAndConfigurePlugin({
+    replSet: true,
+  })
+
+  await createTestApp(plugin)
+}
+
+export const teardownAfterAll = async () => {
+  resetEnv()
+
+  await closeAndStopInMemoryInstance()
+}
+
+export const tearDownAfterEach = async () => {
+  await emptyAllCollections()
+}

--- a/packages/mongodb/test-setup.ts
+++ b/packages/mongodb/test-setup.ts
@@ -11,7 +11,7 @@ export const setupBeforeAll = async () => {
   setupEnvOverride({ PUBLIC_KEY: publicKey, PRIVATE_KEY: privateKey })
 
   await startInMemoryInstanceAndConfigurePlugin({
-    replSet: true,
+    replicaSetOptions: {},
   })
 
   await createTestApp(plugin)


### PR DESCRIPTION
To think about:
- [x] A way to handle retries? Use queues for this? Currently it will get stuck and require manual modifications in the database.
- [x] Should runOnStart in combination with waitForFinish really be the defaults? At least the duplicate error should not stop the server from starting, since it's expected when running multiple instances.
- [x] Are the errors exposed in the right way - so we can make the error property visible in for example Sentry in the event a migration fails.
- [x] Make sure that we don't run the next migration if the previous one hasn't finished in the correct state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced atomic migrations for improved data integrity.
	- Added a new error class for handling migration lock errors.
	- Enhanced migration functionality with improved error handling and logging.
	- Implemented lock handling mechanisms for concurrent migrations.

- **Bug Fixes**
	- Improved error reporting for migration operations.

- **Tests**
	- Added comprehensive test coverage for migration functionality, including success, failure, and concurrency scenarios.

- **Chores**
	- Set up a testing environment for MongoDB-related tests, including setup and teardown functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->