### PR TITLE
Add methods to bull

### DIFF
--- a/.changeset/dry-owls-applaud.md
+++ b/.changeset/dry-owls-applaud.md
@@ -1,0 +1,5 @@
+---
+"@zemble/bull": patch
+---
+
+added getDelayed to ZembleQueueMock

--- a/packages/bull/ZembleQueueMock.ts
+++ b/packages/bull/ZembleQueueMock.ts
@@ -138,9 +138,9 @@ class ZembleQueueMock<DataType = unknown, ResultType extends PromiseLike<unknown
     this.isPaused = false
   }
 
+  // eslint-disable-next-line class-methods-use-this
   async getDelayed() {
-    const jobs = await Promise.all(this.jobs.filter(async (job) => job.isDelayed()))
-    return jobs as unknown as ReturnType<ZembleQueueBull<DataType, ResultType>['getDelayed']>
+    return []
   }
 
   #waitUntilFinishedPromise: Promise<void> | undefined

--- a/packages/bull/ZembleQueueMock.ts
+++ b/packages/bull/ZembleQueueMock.ts
@@ -17,6 +17,7 @@ interface IZembleQueue<DataType = unknown, ReturnType = unknown> {
   readonly resume: ZembleQueueBull<DataType, ReturnType>['resume']
   readonly pause: ZembleQueueBull<DataType, ReturnType>['pause']
   readonly waitUntilEmpty: ZembleQueueBull<DataType, ReturnType>['waitUntilEmpty']
+  readonly getDelayed: ZembleQueueBull<DataType, ReturnType>['getDelayed']
 }
 
 class ZembleQueueMock<DataType = unknown, ResultType extends PromiseLike<unknown> = PromiseLike<unknown>> implements IZembleQueue<DataType, ResultType> {
@@ -38,6 +39,7 @@ class ZembleQueueMock<DataType = unknown, ResultType extends PromiseLike<unknown
     this.getJob = jest.fn(this.getJob.bind(this))
     this.pause = jest.fn(this.pause.bind(this))
     this.resume = jest.fn(this.resume.bind(this))
+    this.getDelayed = jest.fn(this.getDelayed.bind(this))
   }
 
   readonly #worker: ZembleWorker
@@ -134,6 +136,11 @@ class ZembleQueueMock<DataType = unknown, ResultType extends PromiseLike<unknown
 
   async resume(): Promise<void> {
     this.isPaused = false
+  }
+
+  async getDelayed() {
+    const jobs = await Promise.all(this.jobs.filter(async (job) => job.isDelayed()))
+    return jobs as unknown as ReturnType<ZembleQueueBull<DataType, ResultType>['getDelayed']>
   }
 
   #waitUntilFinishedPromise: Promise<void> | undefined

--- a/packages/push-apple/graphql/schema.generated.ts
+++ b/packages/push-apple/graphql/schema.generated.ts
@@ -16,7 +16,6 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
-  /** The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
   JSONObject: { input: any; output: any; }
 };
 
@@ -73,7 +72,6 @@ export type MutationRegisterAppleUpdateLiveActivityPushTokenArgs = {
   activityId: Scalars['ID']['input'];
   appBundleId: Scalars['String']['input'];
   isSandbox?: InputMaybe<Scalars['Boolean']['input']>;
-  liveActivityAttributes: Scalars['JSONObject']['input'];
   liveActivityType: Scalars['String']['input'];
   token: Scalars['String']['input'];
 };
@@ -218,7 +216,7 @@ export type MutationResolvers<ContextType = Zemble.GraphQLContext, ParentType ex
   appleLiveActivityStateUpdated?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationAppleLiveActivityStateUpdatedArgs, 'activityId' | 'liveActivityType' | 'state'>>;
   registerApplePushToken?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationRegisterApplePushTokenArgs, 'appBundleId' | 'platform' | 'token'>>;
   registerAppleStartLiveActivityPushToken?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationRegisterAppleStartLiveActivityPushTokenArgs, 'appBundleId' | 'token'>>;
-  registerAppleUpdateLiveActivityPushToken?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationRegisterAppleUpdateLiveActivityPushTokenArgs, 'activityId' | 'appBundleId' | 'liveActivityAttributes' | 'liveActivityType' | 'token'>>;
+  registerAppleUpdateLiveActivityPushToken?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationRegisterAppleUpdateLiveActivityPushTokenArgs, 'activityId' | 'appBundleId' | 'liveActivityType' | 'token'>>;
   sendPushNotification?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationSendPushNotificationArgs, 'body' | 'pushToken'>>;
   sendSilentPushNotification?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationSendSilentPushNotificationArgs, 'data' | 'pushToken'>>;
   startLiveActivity?: Resolver<ResolversTypes['StartLiveActivityResponse'], ParentType, ContextType, RequireFields<MutationStartLiveActivityArgs, 'data' | 'liveActivityType' | 'pushToken'>>;

--- a/packages/push-expo/graphql/schema.generated.ts
+++ b/packages/push-expo/graphql/schema.generated.ts
@@ -26,7 +26,6 @@ export enum ExpoPushPlatform {
 
 export type Mutation = {
   readonly __typename?: 'Mutation';
-  readonly randomNumber: Scalars['Int']['output'];
   readonly registerExpoPushToken: Scalars['Boolean']['output'];
   readonly sendPushNotification: Scalars['Boolean']['output'];
 };
@@ -42,23 +41,6 @@ export type MutationSendPushNotificationArgs = {
   body: Scalars['String']['input'];
   pushToken: Scalars['String']['input'];
   title: Scalars['String']['input'];
-};
-
-export type Query = {
-  readonly __typename?: 'Query';
-  readonly hello: Scalars['String']['output'];
-};
-
-export type Subscription = {
-  readonly __typename?: 'Subscription';
-  readonly countdown: Scalars['Int']['output'];
-  readonly randomNumber: Scalars['Int']['output'];
-  readonly tick: Scalars['Float']['output'];
-};
-
-
-export type SubscriptionCountdownArgs = {
-  from: Scalars['Int']['input'];
 };
 
 export type WithIndex<TObject> = TObject & Record<string, any>;
@@ -135,44 +117,23 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 export type ResolversTypes = ResolversObject<{
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
   ExpoPushPlatform: ExpoPushPlatform;
-  Float: ResolverTypeWrapper<Scalars['Float']['output']>;
-  Int: ResolverTypeWrapper<Scalars['Int']['output']>;
   Mutation: ResolverTypeWrapper<{}>;
-  Query: ResolverTypeWrapper<{}>;
   String: ResolverTypeWrapper<Scalars['String']['output']>;
-  Subscription: ResolverTypeWrapper<{}>;
 }>;
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = ResolversObject<{
   Boolean: Scalars['Boolean']['output'];
-  Float: Scalars['Float']['output'];
-  Int: Scalars['Int']['output'];
   Mutation: {};
-  Query: {};
   String: Scalars['String']['output'];
-  Subscription: {};
 }>;
 
 export type MutationResolvers<ContextType = Zemble.GraphQLContext, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = ResolversObject<{
-  randomNumber?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   registerExpoPushToken?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationRegisterExpoPushTokenArgs, 'platform' | 'pushToken'>>;
   sendPushNotification?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationSendPushNotificationArgs, 'body' | 'pushToken' | 'title'>>;
 }>;
 
-export type QueryResolvers<ContextType = Zemble.GraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
-  hello?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-}>;
-
-export type SubscriptionResolvers<ContextType = Zemble.GraphQLContext, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = ResolversObject<{
-  countdown?: SubscriptionResolver<ResolversTypes['Int'], "countdown", ParentType, ContextType, RequireFields<SubscriptionCountdownArgs, 'from'>>;
-  randomNumber?: SubscriptionResolver<ResolversTypes['Int'], "randomNumber", ParentType, ContextType>;
-  tick?: SubscriptionResolver<ResolversTypes['Float'], "tick", ParentType, ContextType>;
-}>;
-
 export type Resolvers<ContextType = Zemble.GraphQLContext> = ResolversObject<{
   Mutation?: MutationResolvers<ContextType>;
-  Query?: QueryResolvers<ContextType>;
-  Subscription?: SubscriptionResolvers<ContextType>;
 }>;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `getDelayed` method to `ZembleQueueMock` for retrieving delayed queue items

- **Refactor**
	- Removed `JSONObject` scalar type from Apple push notifications GraphQL schema
	- Simplified Expo push notifications GraphQL schema by removing `Query` and `Subscription` types

- **Bug Fixes**
	- Updated GraphQL schema argument requirements for Apple live activity push token registration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->