### PR TITLE
Add tsup build script for packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint-fix": "biome check --fix --unsafe",
     "typecheck": "bunx turbo run typecheck --concurrency=100% --continue",
     "codegen": "bunx turbo run codegen",
-    "build": "bunx turbo run build",
+    "build": "bun scripts/build-all.ts",
     "prepare": "husky",
     "postinstall": "cp manual-patches/sofa-api/package.json node_modules/sofa-api/",
     "prepush": "bunx turbo run test typecheck --continue",
@@ -63,6 +63,7 @@
     "husky": "^9.1.7",
     "pkg-pr-new": "^0.0.54",
     "syncpack": "^14.0.0-alpha.18",
+    "tsup": "^8.5.0",
     "turbo": "^2.5.4",
     "typescript": "^5.8.3",
     "typescript-json-schema": "^0.65.1"

--- a/scripts/build-all.ts
+++ b/scripts/build-all.ts
@@ -1,0 +1,41 @@
+import { execSync } from 'child_process'
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+const packagesDir = join(__dirname, '..', 'packages')
+
+for (const dir of readdirSync(packagesDir)) {
+  const pkgDir = join(packagesDir, dir)
+  const pkgJsonPath = join(pkgDir, 'package.json')
+  if (!existsSync(pkgJsonPath)) {
+    continue
+  }
+
+  const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf8'))
+  if (pkg.private) {
+    continue
+  }
+
+  /* biome-ignore lint/suspicious/noConsole: progress logging */
+  console.log(`\nBuilding ${pkg.name}`)
+
+  execSync('bunx tsup --config ../../tsup.config.ts', {
+    cwd: pkgDir,
+    stdio: 'inherit',
+    shell: '/bin/bash',
+  })
+
+  const entryTs = (pkg.module || pkg.main || 'index.ts') as string
+  const base = entryTs.replace(/\.ts$/, '')
+  pkg.main = `./dist/${base}.cjs`
+  pkg.module = `./dist/${base}.js`
+  pkg.types = `./dist/${base}.d.ts`
+  pkg.exports = {
+    '.': {
+      import: pkg.module,
+      require: pkg.main,
+      types: pkg.types,
+    },
+  }
+  writeFileSync(pkgJsonPath, `${JSON.stringify(pkg, null, 2)}\n`)
+}

--- a/tsconfig.tsup.json
+++ b/tsconfig.tsup.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitAny": false
+  }
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: [
+    '**/*.ts',
+    '**/*.tsx',
+    '!**/*.test.ts',
+    '!**/*.d.ts',
+    '!**/scripts/*.ts',
+  ],
+  format: ['esm', 'cjs'],
+  dts: true,
+  sourcemap: true,
+  outDir: 'dist',
+  clean: true,
+  skipNodeModulesBundle: true,
+  tsconfig: './tsconfig.tsup.json',
+})


### PR DESCRIPTION
## Summary
- add shared `tsup.tsup.json` to relax strict build checks
- update `tsup.config.ts` to exclude scripts and reference new tsconfig
- enhance build script to write export fields to each package

## Testing
- `bunx biome check --diagnostic-level error`
- `bunx turbo run typecheck --filter=@zemble/core`
- `NODE_OPTIONS=--max-old-space-size=4096 bunx tsup --config ../../tsup.config.ts` on `packages/utils`

------
https://chatgpt.com/codex/tasks/task_e_686c84e6cec0832d891cd1c51b93c7c2