### PR TITLE
Add architecture and agent docs

### DIFF
--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -1,0 +1,45 @@
+# Agent Guide
+
+This repository is a Bun based monorepo. Always run `bun install` in the root
+before executing scripts. Lint and typecheck every change:
+
+```bash
+bunx biome check --fix path/to/file
+bun run typecheck
+```
+
+## Entry Points
+
+- **Server startup**: `@zemble/bun` and `@zemble/node` provide a `serve` function
+  which creates an app with `createApp` and starts the HTTP server.
+- **Plugin definition**: each package usually exposes a `plugin.ts` exporting a
+  `Plugin` instance.
+- **App composition**: apps configure their plugins and call `serve`.
+
+## Tracing Data and Side Effects
+
+- `packages/core/createApp.ts` resolves plugin dependencies and initialises
+  middleware. Provider instances are attached here.
+- Each plugin may register providers via `setupProvider` in its middleware.
+- GraphQL requests are handled by the `@zemble/graphql` plugin using GraphQL
+  Yoga. REST routes are collected by `@zemble/routes` from each plugin's
+  `routes/` folder.
+
+## Common Pitfalls
+
+- Forgetting to run `bun install` or skipping lint/typecheck before committing.
+- Plugins executed outside their directory may not pick up local configuration.
+- When multiple implementations of a provider exist, ensure the
+  `providerStrategies` are set correctly.
+
+## Best Practices
+
+1. Keep plugins small and focused; avoid tight coupling.
+2. Use environment variables for configurable values and provide sensible
+   defaults in plugin configs.
+3. After modifying GraphQL schema or resolvers run `bun run codegen` to update
+types.
+4. Add tests near the functionality they cover and run `bun run test`.
+
+If something is unclear check the plugin’s `plugin.ts` or the core
+implementation in `packages/core`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,45 @@
+# Architecture
+
+Zemble is a monorepo containing multiple apps and packages. Apps live under
+`apps/*` and reusable packages under `packages/*`. The repository relies on
+[Bun](https://bun.sh) as its package manager and script runner.
+
+At runtime an application is created by calling `createApp` from
+`@zemble/core`. The function collects all configured plugins, resolves their
+dependencies and constructs a Hono web server instance:
+
+```ts
+const app = await createApp({
+  plugins: [/* plugin instances */],
+});
+```
+
+Plugins can provide middleware which is invoked during initialisation. The logic
+for merging duplicate plugins and setting up provider strategies can be seen in
+`createApp`:
+
+```ts
+pluginsBeforeResolvingDeps.flatMap((plugin) => [
+  ...plugin.dependencies,
+  plugin,
+])
+```
+
+The server can be started with either the Bun or Node runtime using the
+`@zemble/bun` or `@zemble/node` packages. Both call `createApp`, execute any
+`runBeforeServe` hooks and expose the Hono app via the respective HTTP server.
+
+GraphQL functionality is supplied by the `@zemble/graphql` plugin which uses
+[GraphQL Yoga](https://the-guild.dev/graphql/yoga) and optional Redis based
+pub/sub. REST endpoints are assembled by the `@zemble/routes` plugin through
+file based routing.
+
+Providers such as logging or key–value stores support multiple implementations.
+Provider strategies (`last`, `all`, `failover`, `round-robin`) determine how to
+use multiple providers. Plugins expose their own configuration and can register
+providers for the rest of the system.
+
+Because the core is runtime agnostic and plugins only depend on standard
+interfaces, apps scale horizontally by deploying the assembled server wherever
+Bun or Node runs. Provider strategies allow distributing load or providing
+failover across multiple implementations.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,38 @@
+# Design
+
+The project revolves around a strongly typed plugin system defined in
+`@zemble/core`. Every plugin is represented by the `Plugin` class which stores
+its own configuration, dependencies and optional middleware. Plugins are
+singletons and can detect if they are executed from their own directory to apply
+additional local configuration.
+
+```ts
+class Plugin<TConfig> {
+  constructor(dirname: string, opts?: PluginOpts<TConfig>) { /* ... */ }
+  configure(config?: Partial<TConfig>): this { /* merge config */ }
+  async initializeMiddleware(/* ... */) { /* register providers and hooks */ }
+}
+```
+
+Plugins commonly expose REST endpoints through a `routes` folder and GraphQL
+schemas/resolvers through a `graphql` folder. Middleware allows a plugin to
+traverse other plugins without a direct dependency.
+
+Provider registration uses `setupProvider` to attach concrete implementations of
+services such as logging, email or key–value storage. Multiple providers can be
+active simultaneously and `providerStrategies` decide how they are invoked.
+
+### Conventions
+
+- **Folder layout**: apps under `apps/*`, packages under `packages/*`.
+- **Entry files**: plugin packages typically export a `plugin.ts` which creates a
+  `Plugin` instance.
+- **GraphQL**: place schema files in `graphql/schema.graphql` and resolvers under
+  `graphql/Type/field.ts`.
+- **Routes**: HTTP handlers reside in `routes/` using file-based routing.
+- **Scripts**: linting via Biome (`bunx biome check --fix`), typechecking with
+  `bun run typecheck`, tests with `bun run test`.
+
+The design favours composition over inheritance. Features are implemented in
+small focused plugins that can be combined to create complex systems while
+remaining loosely coupled.


### PR DESCRIPTION
## Summary
- document overall architecture and design decisions
- add a guide for agents and contributors

## Testing
- `bunx biome check --fix ARCHITECTURE.md DESIGN.md AGENT_GUIDE.md`
- `bun run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_687be9b70cdc832d8ec1b508113b42b0