### PR TITLE
improving upload-artifact action

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: playwright-report-${{ inputs.shard_index || 1 }}
+          name: "${{ inputs.shard_count > 1 && format('playwright-report-{0}', inputs.shard_index) || 'playwright-report' }}"
           path: playwright-report/
           retention-days: 30
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: "${{ inputs.shard_count > 1 && format('playwright-report-{0}', inputs.shard_index) || 'playwright-report' }}"
+          name: "${{ inputs.shard_count > 1 && format('playwright-report-{0}', inputs.shard_index || 1) || 'playwright-report' }}"
           path: playwright-report/
           retention-days: 30
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: playwright-report
+          name: playwright-report-${{ inputs.shard_index || 1 }}
           path: playwright-report/
           retention-days: 30
 


### PR DESCRIPTION
Sharded runs all uploaded to the same playwright-report name, which collides on upload-artifact@v4+ (artifacts are now immutable). Appends the shard index so each shard gets a unique artifact.