### PR TITLE
removing absoluteFillObject

### DIFF
--- a/.changeset/primitives-absolute-fill.md
+++ b/.changeset/primitives-absolute-fill.md
@@ -1,0 +1,5 @@
+---
+"@zemble/primitives": patch
+---
+
+Overlay: inline the absolute-fill style instead of spreading `StyleSheet.absoluteFillObject`. React Native 0.85 removed `absoluteFillObject`, which made the spread resolve to `undefined` at runtime (silently dropping `position: 'absolute'`) and fail typechecking. Spreading `StyleSheet.absoluteFill` isn't an option either — it's typed as an opaque `RegisteredStyle` on React Native <= 0.84, so it errors with TS2698 there. The inline literal works across the whole `react-native: "*"` peer range.

--- a/packages/primitives/src/Overlay.tsx
+++ b/packages/primitives/src/Overlay.tsx
@@ -76,7 +76,11 @@ export const Overlay: React.FC<OverlayProps> = ({
       marginVertical: marginY,
       paddingHorizontal: paddingX,
       paddingVertical: paddingY,
-      ...StyleSheet.absoluteFillObject,
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
       ...props,
     }),
     [


### PR DESCRIPTION
## Fix Overlay on React Native 0.85+

`Overlay` spread `StyleSheet.absoluteFillObject`, which React Native removed in 0.85 (present in 0.84, gone from both runtime and types in 0.85+). On newer RN the spread resolves to `undefined`, so the overlay silently loses `position: 'absolute'` — and consumers fail typecheck.

Replaced it with the inline literal:

```diff
-      ...StyleSheet.absoluteFillObject,
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,